### PR TITLE
Update parser to use recursive xpath

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import find_packages, setup
 
-
 setup(
     name='pythomics',
     version='0.3.44',


### PR DESCRIPTION
This enables parsing of mxml files from pepxml without the mzml file present and also fixes searches for alternative proteins/modifications to use a recursive xpath.